### PR TITLE
Check if transaction is present before creating that

### DIFF
--- a/app/models/spree/taxjar.rb
+++ b/app/models/spree/taxjar.rb
@@ -24,13 +24,13 @@ module Spree
       if has_nexus?
         api_params = transaction_parameters
         SpreeTaxjar::Logger.log(__method__, {order: {id: @order.id, number: @order.number}, api_params: api_params}) if SpreeTaxjar::Logger.logger_enabled?
-        taxjar_order = @client.show_order(@order.number)
-        return taxjar_order if taxjar_order.present?
-
-        SpreeTaxjar::Logger.log(__method__, {order: {id: @order.id, number: @order.number}, api_response: api_response}) if SpreeTaxjar::Logger.logger_enabled?
-        api_response = @client.create_order(api_params)
-        SpreeTaxjar::Logger.log(__method__, {order: {id: @order.id, number: @order.number}, api_response: api_response}) if SpreeTaxjar::Logger.logger_enabled?
-        api_response
+        begin
+          api_response = @client.create_order(api_params)
+          SpreeTaxjar::Logger.log(__method__, {order: {id: @order.id, number: @order.number}, api_response: api_response}) if SpreeTaxjar::Logger.logger_enabled?
+          api_response
+        rescue
+          SpreeTaxjar::Logger.log(__method__, {order: {id: @order.id, number: @order.number}, api_response: 'Response with an error'}) if SpreeTaxjar::Logger.logger_enabled?
+        end
       end
     end
 

--- a/app/models/spree/taxjar.rb
+++ b/app/models/spree/taxjar.rb
@@ -24,6 +24,10 @@ module Spree
       if has_nexus?
         api_params = transaction_parameters
         SpreeTaxjar::Logger.log(__method__, {order: {id: @order.id, number: @order.number}, api_params: api_params}) if SpreeTaxjar::Logger.logger_enabled?
+        taxjar_order = @client.show_order(@order.number)
+        return taxjar_order if taxjar_order.present?
+
+        SpreeTaxjar::Logger.log(__method__, {order: {id: @order.id, number: @order.number}, api_response: api_response}) if SpreeTaxjar::Logger.logger_enabled?
         api_response = @client.create_order(api_params)
         SpreeTaxjar::Logger.log(__method__, {order: {id: @order.id, number: @order.number}, api_response: api_response}) if SpreeTaxjar::Logger.logger_enabled?
         api_response


### PR DESCRIPTION
`state_machines` gem callbacks call twice. This generates the error in creating TaxJar transactions. This PR fixes that: we check if a transaction exists, before creating that. 